### PR TITLE
feat: level1 완료

### DIFF
--- a/src/main/java/org/example/plus/aop/AdminAccessLoggingAspect.java
+++ b/src/main/java/org/example/plus/aop/AdminAccessLoggingAspect.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -18,7 +19,7 @@ public class AdminAccessLoggingAspect {
 
     private final HttpServletRequest request;
 
-    @After("execution(* org.example.plus.domain.user.controller.UserController.getUser(..))")
+    @Before("execution(* org.example.plus.domain.user.controller.UserAdminController.changeUserRole(..))")
     public void logAfterChangeUserRole(JoinPoint joinPoint) {
         String userId = String.valueOf(request.getAttribute("userId"));
         String requestUrl = request.getRequestURI();

--- a/src/main/java/org/example/plus/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/plus/config/AuthUserArgumentResolver.java
@@ -39,8 +39,9 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         // JwtFilter 에서 set 한 userId, email, userRole 값을 가져옴
         Long userId = (Long) request.getAttribute("userId");
         String email = (String) request.getAttribute("email");
+        String nickname = (String) request.getAttribute("nickname");
         UserRole userRole = UserRole.of((String) request.getAttribute("userRole"));
 
-        return new AuthUser(userId, email, userRole);
+        return new AuthUser(userId, email, nickname, userRole);
     }
 }

--- a/src/main/java/org/example/plus/config/JwtFilter.java
+++ b/src/main/java/org/example/plus/config/JwtFilter.java
@@ -59,6 +59,7 @@ public class JwtFilter implements Filter {
 
             httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
             httpRequest.setAttribute("email", claims.get("email"));
+            httpRequest.setAttribute("nickname", claims.get("nickname"));
             httpRequest.setAttribute("userRole", claims.get("userRole"));
 
             if (url.startsWith("/admin")) {

--- a/src/main/java/org/example/plus/config/JwtUtil.java
+++ b/src/main/java/org/example/plus/config/JwtUtil.java
@@ -34,7 +34,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, UserRole userRole) {
+    public String createToken(Long userId, String email, String nickName, UserRole userRole) {
         Date date = new Date();
 
         return BEARER_PREFIX +
@@ -42,6 +42,7 @@ public class JwtUtil {
                         .setSubject(String.valueOf(userId))
                         .claim("email", email)
                         .claim("userRole", userRole)
+                        .claim("nickName", nickName)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/org/example/plus/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/plus/domain/auth/dto/request/SignupRequest.java
@@ -14,6 +14,8 @@ public class SignupRequest {
     @NotBlank @Email
     private String email;
     @NotBlank
+    private String nickname;
+    @NotBlank
     private String password;
     @NotBlank
     private String userRole;

--- a/src/main/java/org/example/plus/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/plus/domain/auth/service/AuthService.java
@@ -37,12 +37,13 @@ public class AuthService {
 
         User newUser = new User(
                 signupRequest.getEmail(),
+                signupRequest.getNickname(),
                 encodedPassword,
                 userRole
         );
         User savedUser = userRepository.save(newUser);
 
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole);
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), userRole);
 
         return new SignupResponse(bearerToken);
     }
@@ -56,7 +57,7 @@ public class AuthService {
             throw new AuthException("잘못된 비밀번호입니다.");
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole());
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getNickname(), user.getUserRole());
 
         return new SigninResponse(bearerToken);
     }

--- a/src/main/java/org/example/plus/domain/common/dto/AuthUser.java
+++ b/src/main/java/org/example/plus/domain/common/dto/AuthUser.java
@@ -8,11 +8,13 @@ public class AuthUser {
 
     private final Long id;
     private final String email;
+    private final String nickname;
     private final UserRole userRole;
 
-    public AuthUser(Long id, String email, UserRole userRole) {
+    public AuthUser(Long id, String email, String nickname, UserRole userRole) {
         this.id = id;
         this.email = email;
+        this.nickname = nickname;
         this.userRole = userRole;
     }
 }

--- a/src/main/java/org/example/plus/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/plus/domain/todo/controller/TodoController.java
@@ -9,8 +9,12 @@ import org.example.plus.domain.todo.dto.response.TodoResponse;
 import org.example.plus.domain.todo.dto.response.TodoSaveResponse;
 import org.example.plus.domain.todo.service.TodoService;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,9 +33,12 @@ public class TodoController {
     @GetMapping("/todos")
     public ResponseEntity<Page<TodoResponse>> getTodos(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String weather,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate endDate
     ) {
-        return ResponseEntity.ok(todoService.getTodos(page, size));
+        return ResponseEntity.ok(todoService.getTodos(page, size, weather, startDate, endDate));
     }
 
     @GetMapping("/todos/{todoId}")

--- a/src/main/java/org/example/plus/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/plus/domain/todo/repository/TodoRepository.java
@@ -7,12 +7,27 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
+
+    @Query("SELECT t FROM Todo t " +
+            "LEFT JOIN FETCH t.user u " +
+            "WHERE (:weather IS NULL OR :weather = '' OR t.weather = :weather) " +
+            "AND (:startDate IS NULL OR t.modifiedAt >= :startDate) " +
+            "AND (:endDate IS NULL OR t.modifiedAt <= :endDate) " +
+            "ORDER BY t.modifiedAt DESC")
+    Page<Todo> findTodosByFilters(
+            @Param("weather") String weather,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
+
 
     @Query("SELECT t FROM Todo t " +
             "LEFT JOIN t.user " +

--- a/src/main/java/org/example/plus/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/plus/domain/todo/service/TodoService.java
@@ -19,12 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TodoService {
 
     private final TodoRepository todoRepository;
     private final WeatherClient weatherClient;
 
+    @Transactional
     public TodoSaveResponse saveTodo(AuthUser authUser, TodoSaveRequest todoSaveRequest) {
         User user = User.fromAuthUser(authUser);
 
@@ -47,6 +47,7 @@ public class TodoService {
         );
     }
 
+    @Transactional(readOnly = true)
     public Page<TodoResponse> getTodos(int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
@@ -63,6 +64,7 @@ public class TodoService {
         ));
     }
 
+    @Transactional(readOnly = true)
     public TodoResponse getTodo(long todoId) {
         Todo todo = todoRepository.findByIdWithUser(todoId)
                 .orElseThrow(() -> new InvalidRequestException("Todo not found"));

--- a/src/main/java/org/example/plus/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/plus/domain/todo/service/TodoService.java
@@ -17,6 +17,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 @Service
 @RequiredArgsConstructor
 public class TodoService {
@@ -48,10 +52,14 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public Page<TodoResponse> getTodos(int page, int size) {
+    public Page<TodoResponse> getTodos(int page, int size, String weather, LocalDate startDate, LocalDate endDate) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        Page<Todo> todos = todoRepository.findAllByOrderByModifiedAtDesc(pageable);
+        // 각 해당 날짜가 존재하면 00:00:00, 23:59:59.999999로 변환 -> 날짜만 입력하기 때문에 시간을 강제로 지정
+        LocalDateTime startDateTime = (startDate != null) ? startDate.atStartOfDay() : null;
+        LocalDateTime endDateTime = (endDate != null) ? endDate.atTime(LocalTime.MAX) : null;
+
+        Page<Todo> todos = todoRepository.findTodosByFilters(weather, startDateTime, endDateTime, pageable);
 
         return todos.map(todo -> new TodoResponse(
                 todo.getId(),

--- a/src/main/java/org/example/plus/domain/user/entity/User.java
+++ b/src/main/java/org/example/plus/domain/user/entity/User.java
@@ -17,24 +17,27 @@ public class User extends Timestamped {
     private Long id;
     @Column(unique = true)
     private String email;
+    private String nickname;
     private String password;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
-    public User(String email, String password, UserRole userRole) {
+    public User(String email, String nickname, String password, UserRole userRole) {
         this.email = email;
+        this.nickname = nickname;
         this.password = password;
         this.userRole = userRole;
     }
 
-    private User(Long id, String email, UserRole userRole) {
+    private User(Long id, String email, String nickName, UserRole userRole) {
         this.id = id;
         this.email = email;
+        this.nickname = nickName;
         this.userRole = userRole;
     }
 
     public static User fromAuthUser(AuthUser authUser) {
-        return new User(authUser.getId(), authUser.getEmail(), authUser.getUserRole());
+        return new User(authUser.getId(), authUser.getEmail(), authUser.getNickname(), authUser.getUserRole());
     }
 
     public void changePassword(String password) {

--- a/src/test/java/org/example/plus/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/org/example/plus/domain/todo/controller/TodoControllerTest.java
@@ -35,7 +35,7 @@ class TodoControllerTest {
         // given
         long todoId = 1L;
         String title = "title";
-        AuthUser authUser = new AuthUser(1L, "email", UserRole.USER);
+        AuthUser authUser = new AuthUser(1L, "email", "nickname", UserRole.USER);
         User user = User.fromAuthUser(authUser);
         UserResponse userResponse = new UserResponse(user.getId(), user.getEmail());
         TodoResponse response = new TodoResponse(
@@ -69,9 +69,9 @@ class TodoControllerTest {
 
         // then
         mockMvc.perform(get("/todos/{todoId}", todoId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(HttpStatus.OK.name()))
-                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("Todo not found"));
     }
 }


### PR DESCRIPTION
## 📌 What is this PR ?

플러스 주차 개인 과제 - Level 1 완료 

<br/>

## 🔎 Additions / Changes

## Additions
1. 코드 개선 퀴즈 - Transactional 어노테이션의 이해
2. 코드 추가 퀴즈 - JWT의 이해
3. 코드 개선 퀴즈 - JPA의 이해
4. 테스트 코드 퀴즈 - 컨트롤러 테스트의 이해
5. 코드 개선 퀴즈 - AOP의 이해

## Changes
### 1. 코드 개선 퀴즈 - Transactional 어노테이션의 이해

TodoService 클래스의 각 메서드의 Transactional 어노테이션를 붙임으로써 스프링이 트랜잭션을 관리하도록 함

### 2. 코드 추가 퀴즈 - JWT의 이해

#### User 엔티티 변경
- nickname 필드 추가 (중복 가능)
- nullable여부는 dto에서 validation으로 확인
 
#### AuthService (signup, signin) 개선
- signup 메서드에서 DTO의 nickname 필드를 사용해 User를 생성
- signup, signin에서 JWT 생성 시 nickname을 claim에 추가
 
#### AuthUser 클래스 수정
- 로그인한 사용자의 정보를 가져올 때, nickname도 가져올 수 있도록 필드와 생성자 매개변수 추가
 
#### SignupRequest dto 수정
- nickname 필드를 선언하여 회원 가입 시 닉네임을 필수 입력하도록 설정

#### AuthUserArgumentResolver수정
- resolveArgument 메서드에서 getAttribute("nickname")을 추가하여 nickname을 가져올 수 있도록 변경
- JwtFilter에서 설정한 사용자 정보를 가져와 AuthUser를 생성함

#### JwtUtil 클래스의 createToken 메서드 수정
- claim("nickName", nickName)을 추가하여 JWT claim에 nickname 정보도 포함

#### JwtFilter (doFilter 메서드) 수정
- setAttribute("nickname", claims.get("nickname")) 추가하여 JWT에서 nickname을 추출할 수 있도록 변경

### 3. 코드 개선 퀴즈 - JPA의 이해

#### findTodosByFilters 메서드 추가
- weather, startDateTime, endDateTime, pageable을 파라미터로 받아 조건에 따라 검색할 수 있도록 설정
- JPQL을 사용하여 todo의 수정일 기준으로 기간 검색과 weather 기준 검색을 적용
- 각각의 조건(weather, startDateTime, endDateTime)을 선택적으로 사용할 수 있도록 유동적으로 처리

#### TodoService의 getTodos 수정
- weather, startDateTime, endDateTime을 받을 수 있도록 수정
- 날짜 변환 시 atStartOfDay()와 atTime(LocalTime.MAX)을 사용하여 시간의 시작과 끝을 명확하게 설정

#### TodoController의 getTodos 수정
- weather, startDateTime, endDateTime을 API 요청에서 받을 수 있도록 추가
※ 각 조건별로 별도의 메서드를 생성하는 방법도 고려했으나,
쿼리가 많아질 경우 유지보수가 어려워질 것을 감안하여 현재 방식으로 쿼리를 작성함.

### 4. 테스트 코드 퀴즈 - 컨트롤러 테스트의 이해
#### TodoControllerTest
#### todo_단건_조회에_성공한다() 테스트 수정
- AuthUser 생성 시 nickname 필드 추가

#### todo_단건_조회_시_예외가_발생한다() 테스트 수정
- 기존 테스트에서는 InvalidRequestException 발생 시 예상 응답 코드가 OK로 설정되어 있었음
- 서비스 로직에서 예외 발생 시 BAD_REQUEST로 처리하므로,
테스트 코드에서도 예상 응답을 BAD_REQUEST로 변경하여 실제 응답과 일치하도록 수정

### 5. 코드 개선 퀴즈 - AOP의 이해
#### AdminAccessLoggingAspect 
#### Advice 변경
- logAfterChangeUserRole 메서드의 @After를 @Before로 변경
#### 포인트컷 수정
- 포인트컷 표현식을 UserAdminController.changeUserRole로 변경하여 역할 변경이 일어나기 전에 로그를 기록하도록 개선
<br/>

## 📷 Screenshot

| 기능 | 스크린샷 |
| --- | --- |
| 1-1 todos 정상 생성| ![image](https://github.com/user-attachments/assets/896b633f-9b2b-43f1-8ee4-a3341d5110e2)|
|1-2 jwt claim의 nickname|![image](https://github.com/user-attachments/assets/32f777ba-92b4-4cf7-a216-a683fe51fc57)|
|1-3-1 기본 검색( 검색은 모두 수정일 기준 정렬)|![image](https://github.com/user-attachments/assets/ea7d0b15-ca31-4d5b-968b-ed17ba16c8b6)|
|1-3-2 weather 검색|![image](https://github.com/user-attachments/assets/76e2f008-8f26-4f7a-b1fe-e642eb0ddbc7)|
|1-3-3 startDate검색|![image](https://github.com/user-attachments/assets/35df2f8c-435f-40c4-b3dd-9d77e5b6b8d0)|
|1-3-4 endDate검색|![image](https://github.com/user-attachments/assets/d8598d40-3798-46d2-bdf5-56179a199a0a)|
|1-3-5 startDate+ endDate검색|![image](https://github.com/user-attachments/assets/e5d178ff-797c-4797-8b49-9e61ea344d29)|
|1-3-6 weather  + startDate검색|![image](https://github.com/user-attachments/assets/8ca7b40d-9f49-4a3f-8801-006e1c8b8f9c)|
|1-3-7 weather  + endDate검색|![image](https://github.com/user-attachments/assets/43bdb991-b907-41ff-899a-34dc2a75b72c)|
|1-3-8 weather  + startDate+ endDate검색|![image](https://github.com/user-attachments/assets/8b6c582a-41b7-474b-99f8-ef88f6fdbd3c)|
|1-4 TodoControllerTest의 todo_단건_조회에_성공한다()테스트 성공|![image](https://github.com/user-attachments/assets/f582e130-986f-47eb-902f-264f9594a5b0)|
|1-5 UserAdminController 클래스의 changeUserRole() 메소드 동작| ![image](https://github.com/user-attachments/assets/263025c2-4702-4e06-8897-b83b9a331a15)|

<br/>
